### PR TITLE
Fix add/delete track command for managing playlists

### DIFF
--- a/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
@@ -5,7 +5,6 @@ import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_TRACK;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
@@ -33,15 +33,21 @@ public class TrackAddCommand extends Command {
     private List<Track> argTracksToAdd;
     private Playlist argPlaylist;
 
+    public TrackAddCommand(Playlist targetPlaylist, Track... trackToAdd) {
+        requireNonNull(trackToAdd);
+        requireNonNull(targetPlaylist);
+        this.argPlaylist = targetPlaylist;
+        this.argTracksToAdd = new ArrayList<Track>();
+        for (Track track : trackToAdd) {
+            this.argTracksToAdd.add(track);
+        }
+    }
+
     public TrackAddCommand(Playlist targetPlaylist, List<Track> tracksToAdd) {
         requireNonNull(tracksToAdd);
         requireNonNull(targetPlaylist);
         this.argTracksToAdd = tracksToAdd;
         this.argPlaylist = targetPlaylist;
-    }
-
-    public TrackAddCommand(Playlist targetPlaylist, Track... trackToAdd) {
-        new TrackAddCommand(targetPlaylist, Arrays.asList(trackToAdd));
     }
 
     @Override
@@ -67,8 +73,7 @@ public class TrackAddCommand extends Command {
         // check if tracks exist
         // argTracksToAdd.stream().forEach(track -> System.out.println(track.getFileNameWithoutExtension()));
         for (Track trackToAdd : argTracksToAdd) {
-            Optional<Track> listOfTracks = model.getLibrary()
-                    .getTracks().stream()
+            Optional<Track> listOfTracks = model.getFilteredTrackList().stream()
                     .filter(track -> track.equals(trackToAdd))
                     .findFirst();
             boolean trackExists = listOfTracks.isPresent();
@@ -81,13 +86,16 @@ public class TrackAddCommand extends Command {
         }
 
         for (Track trackToAdd : tracksToAdd) {
-            actualTrack = model.getLibrary().getTracks().stream().filter(track -> track
+            actualTrack = model.getFilteredTrackList().stream().filter(track -> track
                     .equals(trackToAdd)).findFirst().get();
             updatedPlaylist.addTrack(actualTrack);
         }
 
         model.updatePlaylist(actualPlaylist, updatedPlaylist);
         if (tracksNotAdded.isEmpty()) {
+            if (tracksToAdd.size() == 1) {
+                return new CommandResult(String.format(MESSAGE_SUCCESS, tracksToAdd.get(0), actualPlaylist.getName()));
+            }
             return new CommandResult(String.format(MESSAGE_SUCCESS, tracksToAdd, actualPlaylist.getName()));
         }
         return new CommandResult(String.format(MESSAGE_SUCCESS + "\n" + MESSAGE_TRACK_DOES_NOT_EXIST,

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
@@ -16,17 +16,16 @@ import seedu.jxmusic.model.Track;
  */
 public class TrackAddCommand extends Command {
     public static final String COMMAND_PHRASE = "track add";
-    public static final String MESSAGE_SUCCESS = "Track added to playlist: %1$s -> %2$s";
-    public static final String MESSAGE_USAGE = COMMAND_PHRASE + ": Adds a new track to the playlist identified "
-        + "by the name of the track and playlist. "
+    public static final String MESSAGE_SUCCESS = "Tracks added to playlist: %1$s -> %2$s";
+    public static final String MESSAGE_USAGE = COMMAND_PHRASE + ": Adds a new track(s) to the playlist identified "
+        + "by the name of the track and playlist.\n"
         + "Playlist will be modified with new track.\n"
         + "Parameters: [" + PREFIX_PLAYLIST + "PLAYLIST] "
         + "[" + PREFIX_TRACK + "TRACK]...\n"
         + "Example: " + COMMAND_PHRASE + " "
-        + PREFIX_PLAYLIST + "rockPlaylist "
+        + PREFIX_PLAYLIST + "rockPlaylist" + " "
         + PREFIX_TRACK + "rockNRoll";
-    public static final String MESSAGE_DUPLICATE_TRACK = "Track already exists in the playlist: %1$s";
-    public static final String MESSAGE_TRACK_DOES_NOT_EXIST = "Track does not exist: %1$s";
+    public static final String MESSAGE_TRACK_DOES_NOT_EXIST = "These tracks do not exist: %3$s";
     public static final String MESSAGE_PLAYLIST_DOES_NOT_EXIST = "Playlist does not exist: %1$s";
 
     private List<Track> argTracksToAdd;
@@ -60,9 +59,9 @@ public class TrackAddCommand extends Command {
         updatedPlaylist = actualPlaylist.copy();
 
         // check if tracks exist
-        System.out.println(argTracksToAdd.size());
+        // argTracksToAdd.stream().forEach(track -> System.out.println(track.getFileNameWithoutExtension()));
         for (Track trackToAdd : argTracksToAdd) {
-            if (model.getLibrary().getTracks().contains(trackToAdd)) {
+            if (model.getFilteredTrackList().stream().anyMatch(track -> track.equals(trackToAdd))) {
                 tracksToAdd.add(trackToAdd);
             } else {
                 // to display as tracks that cannot be added
@@ -77,7 +76,11 @@ public class TrackAddCommand extends Command {
         }
 
         model.updatePlaylist(actualPlaylist, updatedPlaylist);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, tracksToAdd, actualPlaylist.getName()));
+        if (tracksNotAdded.isEmpty()) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, tracksToAdd, actualPlaylist.getName()));
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS + "\n" + MESSAGE_TRACK_DOES_NOT_EXIST,
+                tracksToAdd, actualPlaylist.getName(), tracksNotAdded));
     }
 
 }

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
@@ -4,10 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_TRACK;
 
-import java.util.List;
-
 import seedu.jxmusic.model.Model;
-import seedu.jxmusic.model.Name;
 import seedu.jxmusic.model.Playlist;
 import seedu.jxmusic.model.Track;
 
@@ -16,7 +13,7 @@ import seedu.jxmusic.model.Track;
  */
 public class TrackAddCommand extends Command {
     public static final String COMMAND_PHRASE = "track add";
-    public static final String MESSAGE_SUCCESS = "Track %1$s added to playlist %2$s";
+    public static final String MESSAGE_SUCCESS = "Track added to playlist: %1$s -> %2$s";
     public static final String MESSAGE_USAGE = COMMAND_PHRASE + ": Adds a new track to the playlist identified "
         + "by the name of the track and playlist. "
         + "Playlist will be modified with new track.\n"
@@ -25,50 +22,55 @@ public class TrackAddCommand extends Command {
         + "Example: " + COMMAND_PHRASE + " "
         + PREFIX_PLAYLIST + "rockPlaylist "
         + PREFIX_TRACK + "rockNRoll";
-    public static final String MESSAGE_DUPLICATE_TRACK = "This track already exists in the playlist: %1$s";
-    public static final String MESSAGE_PLAYLIST_DOES_NOT_EXIST = "This playlist %1$s does not exist";
+    public static final String MESSAGE_DUPLICATE_TRACK = "Track already exists in the playlist: %1$s";
+    public static final String MESSAGE_TRACK_DOES_NOT_EXIST = "Track does not exist: %1$s";
+    public static final String MESSAGE_PLAYLIST_DOES_NOT_EXIST = "Playlist does not exist: %1$s";
 
-    private Track trackToAdd;
-    private Playlist targetPlaylist;
+    private Track argTrackToAdd;
+    private Playlist argPlaylist;
 
     public TrackAddCommand(Track trackToAdd, Playlist targetPlaylist) {
         requireNonNull(trackToAdd);
         requireNonNull(targetPlaylist);
-        this.trackToAdd = trackToAdd;
-        this.targetPlaylist = targetPlaylist;
-    }
-
-    /**
-     * For immutability
-     * @param targetPlaylist
-     * Returns a copy of targetPlaylist
-     */
-    private Playlist copyPlaylist(Playlist targetPlaylist) {
-        List<Track> tracks = targetPlaylist.getTracks();
-        Name nameCopy = targetPlaylist.getName();
-        Playlist playlistCopy = new Playlist(nameCopy);
-        for (Track track : tracks) {
-            playlistCopy.addTrack(track);
-        }
-        return playlistCopy;
+        this.argTrackToAdd = trackToAdd;
+        this.argPlaylist = targetPlaylist;
     }
 
     @Override
     public CommandResult execute(Model model) {
         Playlist updatedPlaylist;
+        Playlist actualPlaylist;
+        Track trackToAdd = null;
 
         // check if playlist exists
-        if (!model.hasPlaylist(targetPlaylist)) {
-            return new CommandResult(String.format(MESSAGE_PLAYLIST_DOES_NOT_EXIST, targetPlaylist.getName()));
+        if (!model.hasPlaylist(argPlaylist)) {
+            return new CommandResult(String.format(MESSAGE_PLAYLIST_DOES_NOT_EXIST, argPlaylist.getName()));
         }
-        updatedPlaylist = copyPlaylist(targetPlaylist);
+
+        // violates law of demeter for read operation due to best access path to Playlist
+        actualPlaylist = model.getLibrary().getPlaylistList()
+                .filtered(playlist -> playlist.isSamePlaylist(argPlaylist))
+                .get(0);
+
+        updatedPlaylist = actualPlaylist;
+
+        // check if track exists
+        if (!model.getLibrary().getTracks().contains(argTrackToAdd)) {
+            return new CommandResult(String.format(MESSAGE_TRACK_DOES_NOT_EXIST, argTrackToAdd
+                    .getFileNameWithoutExtension()));
+        }
+
         // check if track exists in existing playlist
-        if (targetPlaylist.hasTrack(trackToAdd)) {
-            return new CommandResult(String.format(MESSAGE_DUPLICATE_TRACK, trackToAdd));
+        if (actualPlaylist.hasTrack(argTrackToAdd)) {
+            return new CommandResult(String.format(MESSAGE_DUPLICATE_TRACK, argTrackToAdd));
         }
+
+        trackToAdd = model.getLibrary().getTracks().stream().filter(track -> track
+                .equals(argTrackToAdd)).findFirst().get();
+
         updatedPlaylist.addTrack(trackToAdd);
-        model.updatePlaylist(targetPlaylist, updatedPlaylist);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, trackToAdd, targetPlaylist.getName()));
+        model.updatePlaylist(actualPlaylist, updatedPlaylist);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, trackToAdd, actualPlaylist.getName()));
     }
 
 }

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackAddCommand.java
@@ -5,7 +5,9 @@ import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_TRACK;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import seedu.jxmusic.model.Model;
 import seedu.jxmusic.model.Playlist;
@@ -31,11 +33,15 @@ public class TrackAddCommand extends Command {
     private List<Track> argTracksToAdd;
     private Playlist argPlaylist;
 
-    public TrackAddCommand(List<Track> tracksToAdd, Playlist targetPlaylist) {
+    public TrackAddCommand(Playlist targetPlaylist, List<Track> tracksToAdd) {
         requireNonNull(tracksToAdd);
         requireNonNull(targetPlaylist);
         this.argTracksToAdd = tracksToAdd;
         this.argPlaylist = targetPlaylist;
+    }
+
+    public TrackAddCommand(Playlist targetPlaylist, Track... trackToAdd) {
+        new TrackAddCommand(targetPlaylist, Arrays.asList(trackToAdd));
     }
 
     @Override
@@ -61,8 +67,13 @@ public class TrackAddCommand extends Command {
         // check if tracks exist
         // argTracksToAdd.stream().forEach(track -> System.out.println(track.getFileNameWithoutExtension()));
         for (Track trackToAdd : argTracksToAdd) {
-            if (model.getFilteredTrackList().stream().anyMatch(track -> track.equals(trackToAdd))) {
-                tracksToAdd.add(trackToAdd);
+            Optional<Track> listOfTracks = model.getLibrary()
+                    .getTracks().stream()
+                    .filter(track -> track.equals(trackToAdd))
+                    .findFirst();
+            boolean trackExists = listOfTracks.isPresent();
+            if (trackExists) {
+                tracksToAdd.add(listOfTracks.get());
             } else {
                 // to display as tracks that cannot be added
                 tracksNotAdded.add(trackToAdd);

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
@@ -22,6 +22,7 @@ public class TrackDeleteCommand extends Command {
             + PREFIX_PLAYLIST + "rockPlaylist "
             + "1";
     public static final String MESSAGE_INDEX_DOES_NOT_EXIST = "This playlist does not have index: %1$s";
+    public static final String MESSAGE_PLAYLIST_IS_EMPTY = "This playlist is empty";
     public static final String MESSAGE_PLAYLIST_DOES_NOT_EXIST = "This playlist %1$s does not exist";
 
     private Index indexToDelete;
@@ -50,6 +51,11 @@ public class TrackDeleteCommand extends Command {
         actualPlaylist = model.getLibrary().getPlaylistList()
                 .filtered(playlist -> playlist.isSamePlaylist(targetPlaylist))
                 .get(0);
+
+        // check if playlist is empty
+        if (actualPlaylist.getTracks().isEmpty()) {
+            return new CommandResult(MESSAGE_PLAYLIST_IS_EMPTY);
+        }
 
         updatedPlaylist = actualPlaylist.copy();
         // check if track exists in existing playlist

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
@@ -53,19 +53,19 @@ public class TrackDeleteCommand extends Command {
                 .get(0);
 
         // check if playlist is empty
-        if (actualPlaylist.getTracks().isEmpty()) {
+        if (actualPlaylist.isEmpty()) {
             return new CommandResult(MESSAGE_PLAYLIST_IS_EMPTY);
         }
 
         updatedPlaylist = actualPlaylist.copy();
         // check if track exists in existing playlist
-        playlistSize = updatedPlaylist.getTracks().size();
+        playlistSize = updatedPlaylist.getSize();
         if (trackNum > playlistSize) {
             return new CommandResult(String.format(MESSAGE_INDEX_DOES_NOT_EXIST, trackNum));
         }
 
         // get track from trackNum
-        trackToDelete = actualPlaylist.getTracks().get(indexToDelete.getZeroBased());
+        trackToDelete = actualPlaylist.get(indexToDelete.getZeroBased());
 
         if (updatedPlaylist.deleteTrack(trackToDelete)) {
             model.updatePlaylist(actualPlaylist, updatedPlaylist);

--- a/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
+++ b/src/main/java/seedu/jxmusic/logic/commands/TrackDeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.jxmusic.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 
+import seedu.jxmusic.commons.core.index.Index;
 import seedu.jxmusic.model.Model;
 import seedu.jxmusic.model.Playlist;
 import seedu.jxmusic.model.Track;
@@ -20,35 +21,49 @@ public class TrackDeleteCommand extends Command {
             + "Example: " + COMMAND_PHRASE + " "
             + PREFIX_PLAYLIST + "rockPlaylist "
             + "1";
-    public static final String MESSAGE_TRACK_DOES_NOT_EXIST = "This playlist does not have track: %1$s";
+    public static final String MESSAGE_INDEX_DOES_NOT_EXIST = "This playlist does not have index: %1$s";
     public static final String MESSAGE_PLAYLIST_DOES_NOT_EXIST = "This playlist %1$s does not exist";
 
-    private Track trackToDelete;
+    private Index indexToDelete;
     private Playlist targetPlaylist;
 
-    public TrackDeleteCommand(Track trackToDelete, Playlist targetPlaylist) {
-        requireNonNull(trackToDelete);
+    public TrackDeleteCommand(Playlist targetPlaylist, Index indexToDelete) {
+        requireNonNull(indexToDelete);
         requireNonNull(targetPlaylist);
-        this.trackToDelete = trackToDelete;
+        this.indexToDelete = indexToDelete;
         this.targetPlaylist = targetPlaylist;
     }
 
     @Override
     public CommandResult execute(Model model) {
         Playlist updatedPlaylist;
+        Playlist actualPlaylist;
+        int trackNum = indexToDelete.getOneBased();
+        int playlistSize = 0;
+        Track trackToDelete;
 
         // check if playlist exists
         if (!model.hasPlaylist(targetPlaylist)) {
             return new CommandResult(String.format(MESSAGE_PLAYLIST_DOES_NOT_EXIST, targetPlaylist.getName()));
         }
-        updatedPlaylist = targetPlaylist.copy();
+
+        actualPlaylist = model.getLibrary().getPlaylistList()
+                .filtered(playlist -> playlist.isSamePlaylist(targetPlaylist))
+                .get(0);
+
+        updatedPlaylist = actualPlaylist.copy();
         // check if track exists in existing playlist
-        if (!targetPlaylist.hasTrack(trackToDelete)) {
-            return new CommandResult(String.format(MESSAGE_TRACK_DOES_NOT_EXIST, trackToDelete));
+        playlistSize = updatedPlaylist.getTracks().size();
+        if (trackNum > playlistSize) {
+            return new CommandResult(String.format(MESSAGE_INDEX_DOES_NOT_EXIST, trackNum));
         }
+
+        // get track from trackNum
+        trackToDelete = actualPlaylist.getTracks().get(indexToDelete.getZeroBased());
+
         if (updatedPlaylist.deleteTrack(trackToDelete)) {
-            model.updatePlaylist(targetPlaylist, updatedPlaylist);
-            return new CommandResult(String.format(MESSAGE_SUCCESS, trackToDelete, targetPlaylist.getName()));
+            model.updatePlaylist(actualPlaylist, updatedPlaylist);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, trackToDelete, actualPlaylist.getName()));
         }
         return null;
     }

--- a/src/main/java/seedu/jxmusic/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/CliSyntax.java
@@ -7,6 +7,7 @@ public class CliSyntax {
 
     /* Prefix definitions */
     // JxMusic prefixes
+    public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_TRACK = new Prefix("t/");
     public static final Prefix PREFIX_PLAYLIST = new Prefix("p/");
     public static final Prefix PREFIX_TIME = new Prefix("ti/");

--- a/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
@@ -34,7 +34,7 @@ public class TrackAddCommandParser implements Parser<TrackAddCommand> {
         Playlist targetPlaylist = ParserUtil.parsePlaylist(argMultimap.getValue(PREFIX_PLAYLIST).get());
         List<Track> tracksToAdd = ParserUtil.parseTracks(argMultimap.getAllValues(PREFIX_TRACK));
 
-        return new TrackAddCommand(tracksToAdd, targetPlaylist);
+        return new TrackAddCommand(targetPlaylist, tracksToAdd);
     }
 
     /**

--- a/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.jxmusic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_TRACK;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.jxmusic.logic.commands.TrackAddCommand;
@@ -31,9 +32,9 @@ public class TrackAddCommandParser implements Parser<TrackAddCommand> {
         }
 
         Playlist targetPlaylist = ParserUtil.parsePlaylist(argMultimap.getValue(PREFIX_PLAYLIST).get());
-        Track trackToAdd = ParserUtil.parseTrack(argMultimap.getValue(PREFIX_TRACK).get());
+        List<Track> tracksToAdd = ParserUtil.parseTracks(argMultimap.getAllValues(PREFIX_TRACK));
 
-        return new TrackAddCommand(trackToAdd, targetPlaylist);
+        return new TrackAddCommand(tracksToAdd, targetPlaylist);
     }
 
     /**

--- a/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/TrackAddCommandParser.java
@@ -25,7 +25,7 @@ public class TrackAddCommandParser implements Parser<TrackAddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PLAYLIST, PREFIX_TRACK);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PLAYLIST)
+        if (!arePrefixesPresent(argMultimap, PREFIX_PLAYLIST, PREFIX_TRACK)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TrackAddCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/jxmusic/logic/parser/TrackDeleteCommandParser.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/TrackDeleteCommandParser.java
@@ -34,10 +34,8 @@ public class TrackDeleteCommandParser implements Parser<TrackDeleteCommand> {
 
             Playlist targetPlaylist = ParserUtil.parsePlaylist(argMultimap.getValue(PREFIX_PLAYLIST).get());
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
-
-
             return new TrackDeleteCommand(targetPlaylist, index);
-        } catch (ArrayIndexOutOfBoundsException ae) {
+        } catch (ArrayIndexOutOfBoundsException | NullPointerException ex) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT + " args: " + args,
                     TrackDeleteCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/jxmusic/logic/parser/TrackDeleteCommandParser.java
+++ b/src/main/java/seedu/jxmusic/logic/parser/TrackDeleteCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.jxmusic.logic.parser;
 
 import static seedu.jxmusic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.jxmusic.logic.parser.CliSyntax.PREFIX_PLAYLIST;
 
 import java.util.stream.Stream;
@@ -9,7 +10,6 @@ import seedu.jxmusic.commons.core.index.Index;
 import seedu.jxmusic.logic.commands.TrackDeleteCommand;
 import seedu.jxmusic.logic.parser.exceptions.ParseException;
 import seedu.jxmusic.model.Playlist;
-import seedu.jxmusic.model.Track;
 
 /**
  * Parses input arguments and creates a new TrackDeleteCommand object
@@ -23,21 +23,23 @@ public class TrackDeleteCommandParser implements Parser<TrackDeleteCommand> {
      */
     public TrackDeleteCommand parse(String args) throws ParseException {
         try {
-            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PLAYLIST);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PLAYLIST, PREFIX_INDEX);
 
-            Index index = ParserUtil.parseIndex(args.split("\\s+")[3]);
-
-            if (!arePrefixesPresent(argMultimap, PREFIX_PLAYLIST) || !argMultimap.getPreamble().isEmpty()) {
+            if (!arePrefixesPresent(argMultimap, PREFIX_PLAYLIST, PREFIX_INDEX)
+                    || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, TrackDeleteCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                TrackDeleteCommand.MESSAGE_USAGE));
             }
 
             Playlist targetPlaylist = ParserUtil.parsePlaylist(argMultimap.getValue(PREFIX_PLAYLIST).get());
-            Track trackToRemove = targetPlaylist.getTracks().get(index.getOneBased());
+            Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
 
-            return new TrackDeleteCommand(trackToRemove, targetPlaylist);
+
+            return new TrackDeleteCommand(targetPlaylist, index);
         } catch (ArrayIndexOutOfBoundsException ae) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TrackDeleteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT + " args: " + args,
+                    TrackDeleteCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/seedu/jxmusic/model/ModelManager.java
+++ b/src/main/java/seedu/jxmusic/model/ModelManager.java
@@ -34,9 +34,9 @@ public class ModelManager extends ComponentManager implements Model {
 
         library = new Library(readOnlyLibrary);
         filteredPlaylists = new FilteredList<>(library.getPlaylistList());
-        filteredTrackList = new FilteredList<>(library.getObservableTrackList());
-        //ObservableList<Track> trackListFromSet = FXCollections.observableArrayList(library.getTracks());
-        //filteredTrackList = new FilteredList<>(trackListFromSet);
+        //filteredTrackList = new FilteredList<Track>(library.getObservableTrackList());
+        ObservableList<Track> trackListFromSet = FXCollections.observableArrayList(library.getTracks());
+        filteredTrackList = new FilteredList<>(trackListFromSet);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/jxmusic/model/Name.java
+++ b/src/main/java/seedu/jxmusic/model/Name.java
@@ -49,7 +49,7 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && nameString.equals(((Name) other).nameString)); // state check
+                && nameString.toLowerCase().equals(((Name) other).nameString.toLowerCase())); // state check
     }
 
     @Override

--- a/src/main/java/seedu/jxmusic/model/Playlist.java
+++ b/src/main/java/seedu/jxmusic/model/Playlist.java
@@ -122,7 +122,7 @@ public class Playlist {
      */
     public boolean hasTrack(Track targetTrack) {
         for (Track track : getTracks()) {
-            if (track.getFileName().toLowerCase().equals(targetTrack.getFileName().toLowerCase())) {
+            if (track.getFileName().equalsIgnoreCase(targetTrack.getFileName())) {
                 return true;
             }
         }

--- a/src/main/java/seedu/jxmusic/model/Playlist.java
+++ b/src/main/java/seedu/jxmusic/model/Playlist.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import seedu.jxmusic.commons.core.index.Index;
+
 /**
  * Represents a Playlist in the jxmusic book.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -18,6 +20,7 @@ public class Playlist {
 
     // Data fields
     private final List<Track> tracks;
+    private int size;
 
     /**
      * Only name field must be present. List of tracks to be added later.
@@ -26,6 +29,7 @@ public class Playlist {
         requireAllNonNull(name);
         this.name = name;
         this.tracks = new ArrayList<>();
+        this.size = 0;
     }
 
     /**
@@ -37,6 +41,7 @@ public class Playlist {
         requireAllNonNull(name);
         this.name = name;
         this.tracks = tracks;
+        this.size = this.tracks.size();
     }
 
     public Name getName() {
@@ -51,6 +56,13 @@ public class Playlist {
     }
 
     /**
+     * Returns the track of index in the playlist
+     */
+    public Track get(int index) throws ArrayIndexOutOfBoundsException {
+        return Collections.unmodifiableList(tracks).get(index);
+    }
+
+    /**
      * Adds a track into the playlist
      * @param track to be added to the playlist, must not be null
      */
@@ -59,6 +71,7 @@ public class Playlist {
             throw new NullPointerException("Track must not be null");
         }
         tracks.add(track);
+        setSize(getSize() + 1);
     }
 
     /**
@@ -69,7 +82,11 @@ public class Playlist {
         if (track == null) {
             throw new NullPointerException("Track must not be null");
         }
-        return tracks.remove(track);
+        if (tracks.remove(track)) {
+            setSize(getSize() - 1);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -110,6 +127,35 @@ public class Playlist {
             }
         }
         return false;
+    }
+
+    public Index getTrackIndex(Track targetTrack) {
+        int index = 0;
+        for (Track track : getTracks()) {
+            if (track.equals(targetTrack)) {
+                return Index.fromZeroBased(index);
+            }
+            index++;
+        }
+        return Index.fromOneBased(0);
+    }
+
+    private void setSize(int size) {
+        this.size = size;
+    }
+
+    /**
+     * Returns number of tracks in this playlist
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Returns true if there are no tracks in this playlist
+     */
+    public boolean isEmpty() {
+        return (size == 0);
     }
 
     /**

--- a/src/main/java/seedu/jxmusic/model/Playlist.java
+++ b/src/main/java/seedu/jxmusic/model/Playlist.java
@@ -105,7 +105,7 @@ public class Playlist {
      */
     public boolean hasTrack(Track targetTrack) {
         for (Track track : getTracks()) {
-            if (track.getFileName().equalsIgnoreCase(targetTrack.getFileName())) {
+            if (track.getFileName().toLowerCase().equals(targetTrack.getFileName().toLowerCase())) {
                 return true;
             }
         }

--- a/src/main/java/seedu/jxmusic/model/Track.java
+++ b/src/main/java/seedu/jxmusic/model/Track.java
@@ -146,12 +146,13 @@ public class Track {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Track // instanceof handles nulls
-                && fileNameWithoutExtension.equals(((Track) other).fileNameWithoutExtension)); // state check
+                && fileNameWithoutExtension.toLowerCase().equals((
+                        (Track) other).fileNameWithoutExtension.toLowerCase())); // state check
     }
 
     @Override
     public int hashCode() {
-        return fileNameWithoutExtension.hashCode();
+        return fileNameWithoutExtension.toLowerCase().hashCode();
     }
 
     @Override

--- a/src/test/java/seedu/jxmusic/TestApp.java
+++ b/src/test/java/seedu/jxmusic/TestApp.java
@@ -93,6 +93,7 @@ public class TestApp extends MainApp {
     public Model getModel() {
         Model copy = new ModelManager((model.getLibrary()), new UserPrefs());
         ModelHelper.setFilteredList(copy, model.getFilteredPlaylistList());
+        ModelHelper.setFilteredTrackList(copy, model.getFilteredTrackList());
         return copy;
     }
 

--- a/src/test/java/seedu/jxmusic/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/CommandTestUtil.java
@@ -16,6 +16,7 @@ import seedu.jxmusic.model.Library;
 import seedu.jxmusic.model.Model;
 import seedu.jxmusic.model.NameContainsKeywordsPredicate;
 import seedu.jxmusic.model.Playlist;
+import seedu.jxmusic.model.Track;
 // import seedu.jxmusic.testutil.EditPlaylistDescriptorBuilder;
 
 /**
@@ -30,6 +31,7 @@ public class CommandTestUtil {
     public static final String VALID_PLAYLIST_NAME_CHILL = "Chill music";
     public static final String VALID_PLAYLIST_NAME_ROCK = "Rock music";
     public static final String VALID_PLAYLIST_NAME_HIPHOP = "Hip Hop music";
+    public static final String VALID_PLAYLIST_NAME_TEST = "Test";
 
     /** for sfx playlist */
     public static final String VALID_TRACK_NAME_SOS = "SOS Morse Code";
@@ -142,6 +144,34 @@ public class CommandTestUtil {
     public static void deleteFirstPlaylist(Model model) {
         Playlist firstPlaylist = model.getFilteredPlaylistList().get(0);
         model.deletePlaylist(firstPlaylist);
+    }
+
+    /**
+     * Adds a track in {@code model}'s filtered playlist list from {@code model}'s jxmusic book.
+     */
+    public static void addTrack(Model model, Playlist playlist, Track track) {
+        Playlist targetPlaylist = model.getFilteredPlaylistList().stream()
+                .filter(actualPlaylist -> actualPlaylist.isSamePlaylist(playlist)).findFirst().get();
+        targetPlaylist.addTrack(track);
+    }
+
+    /**
+     * Adds tracks in {@code model}'s filtered playlist list from {@code model}'s jxmusic book.
+     */
+    public static void addTracks(Model model, Playlist playlist, List<Track> tracks) {
+        Playlist targetPlaylist = model.getFilteredPlaylistList().stream()
+                .filter(actualPlaylist -> actualPlaylist.equals(playlist)).findFirst().get();
+        tracks.forEach(track -> targetPlaylist.addTrack(model.getFilteredTrackList().stream()
+                .filter(actualTrack -> actualTrack.equals(track)).findFirst().get()));
+    }
+
+    /**
+     * Deletes a track in {@code model}'s filtered playlist list from {@code model}'s jxmusic book.
+     */
+    public static void removeTrack(Model model, Playlist playlist, Track track) {
+        Playlist targetPlaylist = model.getFilteredPlaylistList().stream()
+                .filter(actualPlaylist -> actualPlaylist.equals(playlist)).findFirst().get();
+        targetPlaylist.deleteTrack(track);
     }
 
 }

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -67,7 +67,7 @@ public class TrackAddCommandTest {
     // No need to test if trackToAdd exists: Non-existent track handled by Track class
 
     @Test
-    public void execute_addTrackToPlaylist() {
+    public void executeAddTrackToPlaylist() {
         Playlist oneTrack = addTracksToExpectedModel(trackToAdd);
         expectedModel = new ModelManager(getTestPlaylistLibrary(oneTrack), new UserPrefs());
         String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, trackToAdd, targetPlaylist.getName());
@@ -76,7 +76,7 @@ public class TrackAddCommandTest {
     }
 
     @Test
-    public void execute_addTracksToPlaylist() {
+    public void executeAddTracksToPlaylist() {
         Playlist multipleTracks = addTracksToExpectedModel(tracksToAdd);
         expectedModel = new ModelManager(getTestPlaylistLibrary(multipleTracks), new UserPrefs());
         String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName());
@@ -85,7 +85,7 @@ public class TrackAddCommandTest {
     }
 
     @Test
-    public void execute_addTrackToNonExistentPlaylist() {
+    public void executeAddTrackToNonExistentPlaylist() {
         expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
         TrackAddCommand command = new TrackAddCommand(targetPlaylist, tracksToAdd);

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -4,10 +4,11 @@ package seedu.jxmusic.logic.commands;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_IHOJIN;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_MARBLES;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.jxmusic.testutil.TypicalPlaylistList.getModifiedTypicalLibrary;
+import static seedu.jxmusic.testutil.TypicalPlaylistList.getTestPlaylistLibrary;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibrary;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
@@ -26,52 +27,71 @@ import seedu.jxmusic.testutil.TypicalPlaylistList;
 public class TrackAddCommandTest {
     private Model model;
     private Model expectedModel;
-    private Model expectedUnchangedModel;
     private CommandHistory commandHistory = new CommandHistory();
-    private List<Track> tracksToAdd;
+    private List<Track> tracksToAdd = new ArrayList<Track>();
+    private Track trackToAdd;
     private Playlist targetPlaylist;
 
     @Before
     public void setUp() {
-        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
-        tracksToAdd = new ArrayList<Track>();
-        tracksToAdd.add(trackToAdd);
-        trackToAdd = new Track(new Name(VALID_TRACK_NAME_IHOJIN));
-        tracksToAdd.add(trackToAdd);
-        targetPlaylist = TypicalPlaylistList.ANIME;
+        trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        initTracksToAdd();
+        targetPlaylist = TypicalPlaylistList.TEST;
         model = new ModelManager(getTypicalLibrary(), new UserPrefs());
-        expectedUnchangedModel = new ModelManager(model.getLibrary(), new UserPrefs());
-        expectedModel = new ModelManager(getModifiedTypicalLibrary(), new UserPrefs());
+    }
+
+    private void initTracksToAdd() {
+        tracksToAdd.add(new Track(new Name(VALID_TRACK_NAME_MARBLES)));
+        tracksToAdd.add(new Track(new Name(VALID_TRACK_NAME_IHOJIN)));
+    }
+
+    /**
+     * @param tracksToAdd each tested track that is required to be added into model
+     * @return
+     */
+    private Playlist addTracksToExpectedModel(List<Track> tracksToAdd) {
+        Playlist playlistToAdd = targetPlaylist.copy();
+        for (Track track : tracksToAdd) {
+            playlistToAdd.addTrack(track);
+        }
+        return playlistToAdd;
+    }
+
+    /**
+     * see above
+     */
+    private Playlist addTracksToExpectedModel(Track... tracks) {
+        return addTracksToExpectedModel(Arrays.asList(tracks));
     }
 
     // No need to test if trackToAdd exists: Non-existent track handled by Track class
 
     @Test
     public void execute_addTrackToPlaylist() {
-        // tracksToAdd.stream().forEach(track -> System.out.println(track.getFileNameWithoutExtension()));
-        // Track trackToAdd = tracksToAdd.get(1);
+        Playlist oneTrack = addTracksToExpectedModel(trackToAdd);
+        expectedModel = new ModelManager(getTestPlaylistLibrary(oneTrack), new UserPrefs());
+        String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, trackToAdd, targetPlaylist.getName());
+        TrackAddCommand command = new TrackAddCommand(targetPlaylist, trackToAdd);
+        assertCommandSuccess(command, model, commandHistory, successMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addTracksToPlaylist() {
+        Playlist multipleTracks = addTracksToExpectedModel(tracksToAdd);
+        expectedModel = new ModelManager(getTestPlaylistLibrary(multipleTracks), new UserPrefs());
         String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName());
         TrackAddCommand command = new TrackAddCommand(targetPlaylist, tracksToAdd);
         assertCommandSuccess(command, model, commandHistory, successMessage, expectedModel);
     }
 
-    /*@Test
-    public void execute_addDuplicateTrackToPlaylist() {
-        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
-        tracksToAdd.add(trackToAdd);
-        targetPlaylist = TypicalPlaylistList.SFX;
-        assertCommandSuccess(new TrackAddCommand(targetPlaylist, tracksToAdd), model, commandHistory,
-                String.format(TrackAddCommand.MESSAGE_DUPLICATE_TRACK, tracksToAdd), expectedUnchangedModel);
-    }*/
-
     @Test
     public void execute_addTrackToNonExistentPlaylist() {
-        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
-        tracksToAdd.add(trackToAdd);
+        expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
-        assertCommandSuccess(new TrackAddCommand(targetPlaylist, tracksToAdd), model, commandHistory,
+        TrackAddCommand command = new TrackAddCommand(targetPlaylist, tracksToAdd);
+        assertCommandSuccess(command, model, commandHistory,
                 String.format(TrackAddCommand.MESSAGE_PLAYLIST_DOES_NOT_EXIST,
-                        targetPlaylist.getName()), expectedUnchangedModel);
+                        targetPlaylist.getName()), expectedModel);
     }
 }
 

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -36,6 +36,8 @@ public class TrackAddCommandTest {
         expectedModel = new ModelManager(getTypicalLibraryAfterTrackAdd(trackToAdd), new UserPrefs());
     }
 
+    // No need to test if trackToAdd exists: Non-existent track handled by Track class
+
     @Test
     public void execute_addTrackToPlaylist() {
         assertCommandSuccess(new TrackAddCommand(trackToAdd, targetPlaylist), model, commandHistory,

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -6,6 +6,9 @@ import static seedu.jxmusic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibrary;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibraryAfterTrackAdd;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,12 +27,14 @@ public class TrackAddCommandTest {
     private Model expectedModel;
     private Model expectedUnchangedModel;
     private CommandHistory commandHistory = new CommandHistory();
-    private Track trackToAdd;
+    private List<Track> tracksToAdd;
     private Playlist targetPlaylist;
 
     @Before
     public void setUp() {
-        trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        tracksToAdd = new ArrayList<Track>();
+        tracksToAdd.add(trackToAdd);
         targetPlaylist = TypicalPlaylistList.ANIME;
         model = new ModelManager(getTypicalLibrary(), new UserPrefs());
         expectedUnchangedModel = new ModelManager(model.getLibrary(), new UserPrefs());
@@ -40,23 +45,25 @@ public class TrackAddCommandTest {
 
     @Test
     public void execute_addTrackToPlaylist() {
-        assertCommandSuccess(new TrackAddCommand(trackToAdd, targetPlaylist), model, commandHistory,
-                String.format(TrackAddCommand.MESSAGE_SUCCESS, trackToAdd, targetPlaylist.getName()), expectedModel);
+        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
+                String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName()), expectedModel);
     }
 
     @Test
     public void execute_addDuplicateTrackToPlaylist() {
-        trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        tracksToAdd.add(trackToAdd);
         targetPlaylist = TypicalPlaylistList.SFX;
-        assertCommandSuccess(new TrackAddCommand(trackToAdd, targetPlaylist), model, commandHistory,
-                String.format(TrackAddCommand.MESSAGE_DUPLICATE_TRACK, trackToAdd), expectedUnchangedModel);
+        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
+                String.format(TrackAddCommand.MESSAGE_DUPLICATE_TRACK, tracksToAdd), expectedUnchangedModel);
     }
 
     @Test
     public void execute_addTrackToNonExistentPlaylist() {
-        trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+        tracksToAdd.add(trackToAdd);
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
-        assertCommandSuccess(new TrackAddCommand(trackToAdd, targetPlaylist), model, commandHistory,
+        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
                 String.format(TrackAddCommand.MESSAGE_PLAYLIST_DOES_NOT_EXIST,
                         targetPlaylist.getName()), expectedUnchangedModel);
     }

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -48,8 +48,10 @@ public class TrackAddCommandTest {
 
     @Test
     public void execute_addTrackToPlaylist() {
+        // tracksToAdd.stream().forEach(track -> System.out.println(track.getFileNameWithoutExtension()));
+        // Track trackToAdd = tracksToAdd.get(1);
         String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName());
-        TrackAddCommand command = new TrackAddCommand(tracksToAdd, targetPlaylist);
+        TrackAddCommand command = new TrackAddCommand(targetPlaylist, tracksToAdd);
         assertCommandSuccess(command, model, commandHistory, successMessage, expectedModel);
     }
 
@@ -58,7 +60,7 @@ public class TrackAddCommandTest {
         Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         tracksToAdd.add(trackToAdd);
         targetPlaylist = TypicalPlaylistList.SFX;
-        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
+        assertCommandSuccess(new TrackAddCommand(targetPlaylist, tracksToAdd), model, commandHistory,
                 String.format(TrackAddCommand.MESSAGE_DUPLICATE_TRACK, tracksToAdd), expectedUnchangedModel);
     }*/
 
@@ -67,7 +69,7 @@ public class TrackAddCommandTest {
         Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         tracksToAdd.add(trackToAdd);
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
-        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
+        assertCommandSuccess(new TrackAddCommand(targetPlaylist, tracksToAdd), model, commandHistory,
                 String.format(TrackAddCommand.MESSAGE_PLAYLIST_DOES_NOT_EXIST,
                         targetPlaylist.getName()), expectedUnchangedModel);
     }

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackAddCommandTest.java
@@ -1,10 +1,11 @@
 package seedu.jxmusic.logic.commands;
 
 // imports
+import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_IHOJIN;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_MARBLES;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.jxmusic.testutil.TypicalPlaylistList.getModifiedTypicalLibrary;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibrary;
-import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibraryAfterTrackAdd;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,28 +36,31 @@ public class TrackAddCommandTest {
         Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         tracksToAdd = new ArrayList<Track>();
         tracksToAdd.add(trackToAdd);
+        trackToAdd = new Track(new Name(VALID_TRACK_NAME_IHOJIN));
+        tracksToAdd.add(trackToAdd);
         targetPlaylist = TypicalPlaylistList.ANIME;
         model = new ModelManager(getTypicalLibrary(), new UserPrefs());
         expectedUnchangedModel = new ModelManager(model.getLibrary(), new UserPrefs());
-        expectedModel = new ModelManager(getTypicalLibraryAfterTrackAdd(trackToAdd), new UserPrefs());
+        expectedModel = new ModelManager(getModifiedTypicalLibrary(), new UserPrefs());
     }
 
     // No need to test if trackToAdd exists: Non-existent track handled by Track class
 
     @Test
     public void execute_addTrackToPlaylist() {
-        assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
-                String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName()), expectedModel);
+        String successMessage = String.format(TrackAddCommand.MESSAGE_SUCCESS, tracksToAdd, targetPlaylist.getName());
+        TrackAddCommand command = new TrackAddCommand(tracksToAdd, targetPlaylist);
+        assertCommandSuccess(command, model, commandHistory, successMessage, expectedModel);
     }
 
-    @Test
+    /*@Test
     public void execute_addDuplicateTrackToPlaylist() {
         Track trackToAdd = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         tracksToAdd.add(trackToAdd);
         targetPlaylist = TypicalPlaylistList.SFX;
         assertCommandSuccess(new TrackAddCommand(tracksToAdd, targetPlaylist), model, commandHistory,
                 String.format(TrackAddCommand.MESSAGE_DUPLICATE_TRACK, tracksToAdd), expectedUnchangedModel);
-    }
+    }*/
 
     @Test
     public void execute_addTrackToNonExistentPlaylist() {

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
@@ -36,7 +36,7 @@ public class TrackDeleteCommandTest {
     }
 
     @Test
-    public void execute_deleteIndexFromPlaylist() {
+    public void executeDeleteIndexFromPlaylist() {
         targetPlaylist.addTrack(new Track(new Name(VALID_TRACK_NAME_MARBLES)));
         Index lastTrackNum = Index.fromOneBased(targetPlaylist.getSize());
         trackToDelete = targetPlaylist.getTracks().get(lastTrackNum.getZeroBased());
@@ -54,7 +54,7 @@ public class TrackDeleteCommandTest {
     }
 
     @Test
-    public void execute_removeNonExistentIndexFromPlaylist() {
+    public void executeDeleteNonExistentIndexFromPlaylist() {
         targetPlaylist = TypicalPlaylistList.ANIME;
         index = Index.fromZeroBased(targetPlaylist.getTracks().size() + 1);
         assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
@@ -63,7 +63,7 @@ public class TrackDeleteCommandTest {
     }
 
     @Test
-    public void execute_deleteIndexFromNonExistentPlaylist() {
+    public void executeDeleteIndexFromNonExistentPlaylist() {
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
         index = Index.fromOneBased(1);

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
@@ -3,7 +3,7 @@ package seedu.jxmusic.logic.commands;
 // imports
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_MARBLES;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.jxmusic.testutil.TypicalPlaylistList.getModifiedTypicalLibrary;
+import static seedu.jxmusic.testutil.TypicalPlaylistList.getTestPlaylistLibrary;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibrary;
 
 import org.junit.Before;
@@ -30,29 +30,31 @@ public class TrackDeleteCommandTest {
 
     @Before
     public void setUp() {
-        // setup library with the track to delete
-        targetPlaylist = TypicalPlaylistList.TEST_ANIME;
-        Index lastTrackNum = Index.fromOneBased(targetPlaylist.getSize());
-        trackToDelete = targetPlaylist.getTracks().get(lastTrackNum.getZeroBased());
-        model = new ModelManager(getModifiedTypicalLibrary(), new UserPrefs());
+        targetPlaylist = TypicalPlaylistList.TEST.copy();
+        model = new ModelManager(getTestPlaylistLibrary(targetPlaylist), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
     }
 
     @Test
     public void execute_deleteIndexFromPlaylist() {
-        expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
-        targetPlaylist = TypicalPlaylistList.TEST_ANIME;
+        targetPlaylist.addTrack(new Track(new Name(VALID_TRACK_NAME_MARBLES)));
+        Index lastTrackNum = Index.fromOneBased(targetPlaylist.getSize());
+        trackToDelete = targetPlaylist.getTracks().get(lastTrackNum.getZeroBased());
+
+        // setup library with the track to delete
+        model = new ModelManager(getTestPlaylistLibrary(targetPlaylist), new UserPrefs());
         trackToDelete = targetPlaylist.getTracks().stream()
                 .filter(Track -> Track.getFileNameWithoutExtension().equals(VALID_TRACK_NAME_MARBLES))
                 .findFirst().get();
         index = targetPlaylist.getTrackIndex(trackToDelete);
-        assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
-                String.format(
-                        TrackDeleteCommand.MESSAGE_SUCCESS, trackToDelete, targetPlaylist.getName()), expectedModel);
+        Command command = new TrackDeleteCommand(targetPlaylist, index);
+        assertCommandSuccess(command, model, commandHistory,
+                String.format(TrackDeleteCommand.MESSAGE_SUCCESS, trackToDelete,
+                        targetPlaylist.getName()), expectedModel);
     }
 
     @Test
     public void execute_removeNonExistentIndexFromPlaylist() {
-        expectedModel = new ModelManager(model.getLibrary(), new UserPrefs());
         targetPlaylist = TypicalPlaylistList.ANIME;
         index = Index.fromZeroBased(targetPlaylist.getTracks().size() + 1);
         assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
@@ -62,7 +64,6 @@ public class TrackDeleteCommandTest {
 
     @Test
     public void execute_deleteIndexFromNonExistentPlaylist() {
-        expectedModel = new ModelManager(model.getLibrary(), new UserPrefs());
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
         index = Index.fromOneBased(1);

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
@@ -3,8 +3,8 @@ package seedu.jxmusic.logic.commands;
 // imports
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_MARBLES;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.jxmusic.testutil.TypicalPlaylistList.getModifiedTypicalLibrary;
 import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibrary;
-import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibraryAfterTrackAdd;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +23,6 @@ import seedu.jxmusic.testutil.TypicalPlaylistList;
 public class TrackDeleteCommandTest {
     private Model model;
     private Model expectedModel;
-    private Model expectedUnchangedModel;
     private CommandHistory commandHistory = new CommandHistory();
     private Index index;
     private Track trackToDelete;
@@ -31,38 +30,45 @@ public class TrackDeleteCommandTest {
 
     @Before
     public void setUp() {
-        index = Index.fromOneBased(1);
-        trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
-        targetPlaylist = TypicalPlaylistList.TEST_ANIME;
         // setup library with the track to delete
-        model = new ModelManager(getTypicalLibraryAfterTrackAdd(trackToDelete), new UserPrefs());
-        expectedUnchangedModel = new ModelManager(model.getLibrary(), new UserPrefs());
-        // setup expected model with library that has track deleted
-        expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
+        targetPlaylist = TypicalPlaylistList.TEST_ANIME;
+        Index lastTrackNum = Index.fromOneBased(targetPlaylist.getSize());
+        trackToDelete = targetPlaylist.getTracks().get(lastTrackNum.getZeroBased());
+        model = new ModelManager(getModifiedTypicalLibrary(), new UserPrefs());
     }
 
     @Test
-    public void execute_deleteTrackFromPlaylist() {
+    public void execute_deleteIndexFromPlaylist() {
+        expectedModel = new ModelManager(getTypicalLibrary(), new UserPrefs());
+        targetPlaylist = TypicalPlaylistList.TEST_ANIME;
+        trackToDelete = targetPlaylist.getTracks().stream()
+                .filter(Track -> Track.getFileNameWithoutExtension().equals(VALID_TRACK_NAME_MARBLES))
+                .findFirst().get();
+        index = targetPlaylist.getTrackIndex(trackToDelete);
         assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
                 String.format(
                         TrackDeleteCommand.MESSAGE_SUCCESS, trackToDelete, targetPlaylist.getName()), expectedModel);
     }
 
     @Test
-    public void execute_removeNonExistentTrackFromPlaylist() {
-        trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
+    public void execute_removeNonExistentIndexFromPlaylist() {
+        expectedModel = new ModelManager(model.getLibrary(), new UserPrefs());
         targetPlaylist = TypicalPlaylistList.ANIME;
+        index = Index.fromZeroBased(targetPlaylist.getTracks().size() + 1);
         assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
-                String.format(TrackDeleteCommand.MESSAGE_INDEX_DOES_NOT_EXIST, trackToDelete), expectedUnchangedModel);
+                String.format(TrackDeleteCommand.MESSAGE_INDEX_DOES_NOT_EXIST,
+                        index.getOneBased()), expectedModel);
     }
 
     @Test
-    public void execute_deleteTrackFromNonExistentPlaylist() {
+    public void execute_deleteIndexFromNonExistentPlaylist() {
+        expectedModel = new ModelManager(model.getLibrary(), new UserPrefs());
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
+        index = Index.fromOneBased(1);
         assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
                 String.format(TrackDeleteCommand.MESSAGE_PLAYLIST_DOES_NOT_EXIST,
-                        targetPlaylist.getName()), expectedUnchangedModel);
+                        targetPlaylist.getName()), expectedModel);
     }
 }
 

--- a/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
+++ b/src/test/java/seedu/jxmusic/logic/commands/TrackDeleteCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.jxmusic.testutil.TypicalPlaylistList.getTypicalLibraryAfterT
 import org.junit.Before;
 import org.junit.Test;
 
+import seedu.jxmusic.commons.core.index.Index;
 import seedu.jxmusic.logic.CommandHistory;
 
 import seedu.jxmusic.model.Model;
@@ -24,11 +25,13 @@ public class TrackDeleteCommandTest {
     private Model expectedModel;
     private Model expectedUnchangedModel;
     private CommandHistory commandHistory = new CommandHistory();
+    private Index index;
     private Track trackToDelete;
     private Playlist targetPlaylist;
 
     @Before
     public void setUp() {
+        index = Index.fromOneBased(1);
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = TypicalPlaylistList.TEST_ANIME;
         // setup library with the track to delete
@@ -40,7 +43,7 @@ public class TrackDeleteCommandTest {
 
     @Test
     public void execute_deleteTrackFromPlaylist() {
-        assertCommandSuccess(new TrackDeleteCommand(trackToDelete, targetPlaylist), model, commandHistory,
+        assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
                 String.format(
                         TrackDeleteCommand.MESSAGE_SUCCESS, trackToDelete, targetPlaylist.getName()), expectedModel);
     }
@@ -49,15 +52,15 @@ public class TrackDeleteCommandTest {
     public void execute_removeNonExistentTrackFromPlaylist() {
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = TypicalPlaylistList.ANIME;
-        assertCommandSuccess(new TrackDeleteCommand(trackToDelete, targetPlaylist), model, commandHistory,
-                String.format(TrackDeleteCommand.MESSAGE_TRACK_DOES_NOT_EXIST, trackToDelete), expectedUnchangedModel);
+        assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
+                String.format(TrackDeleteCommand.MESSAGE_INDEX_DOES_NOT_EXIST, trackToDelete), expectedUnchangedModel);
     }
 
     @Test
     public void execute_deleteTrackFromNonExistentPlaylist() {
         trackToDelete = new Track(new Name(VALID_TRACK_NAME_MARBLES));
         targetPlaylist = new Playlist(new Name("playlistNameDoesNotExist"));
-        assertCommandSuccess(new TrackDeleteCommand(trackToDelete, targetPlaylist), model, commandHistory,
+        assertCommandSuccess(new TrackDeleteCommand(targetPlaylist, index), model, commandHistory,
                 String.format(TrackDeleteCommand.MESSAGE_PLAYLIST_DOES_NOT_EXIST,
                         targetPlaylist.getName()), expectedUnchangedModel);
     }

--- a/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
+++ b/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
@@ -90,7 +90,8 @@ public class TypicalPlaylistList {
     }
 
     public static List<Playlist> getTestPlaylistList(Playlist testPlaylist) {
-        ArrayList<Playlist> result = new ArrayList<>(Arrays.asList(EMPTY, SFX, ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));
+        ArrayList<Playlist> result = new ArrayList<>(
+                Arrays.asList(EMPTY, SFX, ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));
         result.add(testPlaylist);
         return result;
     }

--- a/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
+++ b/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
@@ -7,6 +7,7 @@ import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_PLAYLIST_NAME_H
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_PLAYLIST_NAME_INSTRUMENTAL;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_PLAYLIST_NAME_ROCK;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_PLAYLIST_NAME_SFX;
+import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_PLAYLIST_NAME_TEST;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_BELL;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_HAIKEI;
 import static seedu.jxmusic.logic.commands.CommandTestUtil.VALID_TRACK_NAME_IHOJIN;
@@ -19,6 +20,7 @@ import java.util.List;
 
 import seedu.jxmusic.model.Library;
 import seedu.jxmusic.model.Playlist;
+import seedu.jxmusic.model.Track;
 
 /**
  * A utility class containing a list of {@code Playlist} objects to be used in tests.
@@ -32,9 +34,6 @@ public class TypicalPlaylistList {
             .withTracks(VALID_TRACK_NAME_SOS, VALID_TRACK_NAME_BELL, VALID_TRACK_NAME_MARBLES).build();
     public static final Playlist ANIME = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_ANIME)
             .withTracks(VALID_TRACK_NAME_HAIKEI, VALID_TRACK_NAME_IHOJIN).build();
-    // for TrackAddCommand, TrackRemoveCommand test
-    public static final Playlist TEST_ANIME = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_ANIME)
-            .withTracks(VALID_TRACK_NAME_HAIKEI, VALID_TRACK_NAME_IHOJIN, VALID_TRACK_NAME_MARBLES).build();
     public static final Playlist INSTRUMENTAL = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_INSTRUMENTAL)
             .withTracks(VALID_TRACK_NAME_IHOJIN).build();
     public static final Playlist CHILL = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_CHILL)
@@ -43,6 +42,15 @@ public class TypicalPlaylistList {
             .withTracks(VALID_TRACK_NAME_SOS).build();
     public static final Playlist HIPHOP = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_HIPHOP)
             .withTracks(VALID_TRACK_NAME_MARBLES).build();
+    public static final Playlist TEST = new PlaylistBuilder().withName(VALID_PLAYLIST_NAME_TEST).build();
+
+    public static final List<Track> ALL_SAMPLE_TRACKS = new ArrayList<>(
+            Arrays.asList(
+            new TrackBuilder().withName(VALID_TRACK_NAME_MARBLES).build(),
+            new TrackBuilder().withName(VALID_TRACK_NAME_IHOJIN).build(),
+            new TrackBuilder().withName(VALID_TRACK_NAME_BELL).build(),
+            new TrackBuilder().withName(VALID_TRACK_NAME_HAIKEI).build(),
+            new TrackBuilder().withName(VALID_TRACK_NAME_SOS).build()));
 
 
     public static final String KEYWORD_MATCHING_MUSIC = "music"; // A keyword that matches name with "music"
@@ -57,23 +65,37 @@ public class TypicalPlaylistList {
         for (Playlist playlist : getTypicalPlaylistList()) {
             library.addPlaylist(playlist);
         }
+        for (Track track : getTypicalTrackList()) {
+            library.addTrack(track);
+        }
         return library;
     }
 
     /**
      * Returns an {@code Library} with all the typical playlists after adding an additional track.
      */
-    public static Library getModifiedTypicalLibrary() {
+    public static Library getTestPlaylistLibrary(Playlist testPlaylist) {
         Library library = new Library();
-        ArrayList<Playlist> newLibrary = new ArrayList<>(
-                Arrays.asList(EMPTY, SFX, TEST_ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));
-        for (Playlist playlist : newLibrary) {
+        for (Playlist playlist : getTestPlaylistList(testPlaylist)) {
             library.addPlaylist(playlist);
+        }
+        for (Track track : getTypicalTrackList()) {
+            library.addTrack(track);
         }
         return library;
     }
 
     public static List<Playlist> getTypicalPlaylistList() {
-        return new ArrayList<>(Arrays.asList(EMPTY, SFX, ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));
+        return new ArrayList<>(Arrays.asList(EMPTY, SFX, ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP, TEST));
+    }
+
+    public static List<Playlist> getTestPlaylistList(Playlist testPlaylist) {
+        ArrayList<Playlist> result = new ArrayList<>(Arrays.asList(EMPTY, SFX, ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));
+        result.add(testPlaylist);
+        return result;
+    }
+
+    public static List<Track> getTypicalTrackList() {
+        return ALL_SAMPLE_TRACKS;
     }
 }

--- a/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
+++ b/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import seedu.jxmusic.model.Library;
 import seedu.jxmusic.model.Playlist;
-import seedu.jxmusic.model.Track;
 
 /**
  * A utility class containing a list of {@code Playlist} objects to be used in tests.

--- a/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
+++ b/src/test/java/seedu/jxmusic/testutil/TypicalPlaylistList.java
@@ -64,7 +64,7 @@ public class TypicalPlaylistList {
     /**
      * Returns an {@code Library} with all the typical playlists after adding an additional track.
      */
-    public static Library getTypicalLibraryAfterTrackAdd(Track trackToAdd) {
+    public static Library getModifiedTypicalLibrary() {
         Library library = new Library();
         ArrayList<Playlist> newLibrary = new ArrayList<>(
                 Arrays.asList(EMPTY, SFX, TEST_ANIME, INSTRUMENTAL, CHILL, ROCK, HIPHOP));

--- a/src/test/java/systemtests/ModelHelper.java
+++ b/src/test/java/systemtests/ModelHelper.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 
 import seedu.jxmusic.model.Model;
 import seedu.jxmusic.model.Playlist;
+import seedu.jxmusic.model.Track;
 
 /**
  * Contains helper methods to set up {@code Model} for testing.
@@ -14,6 +15,25 @@ import seedu.jxmusic.model.Playlist;
 public class ModelHelper {
 
     private static final Predicate<Playlist> PREDICATE_MATCHING_NO_PLAYLISTS = unused -> false;
+    private static final Predicate<Track> PREDICATE_MATCHING_NO_TRACKS = unused -> false;
+
+
+    /**
+     * Updates {@code model}'s filtered track list to display only {@code toDisplay}.
+     */
+    public static void setFilteredTrackList(Model model, List<Track> toDisplay) {
+        Optional<Predicate<Track>> predicate =
+                toDisplay.stream().map(ModelHelper::getPredicateMatching).reduce(Predicate::or);
+
+        model.updateFilteredTrackList(predicate.orElse(PREDICATE_MATCHING_NO_TRACKS));
+    }
+
+    /**
+     * @see ModelHelper#setFilteredTrackList(Model, List)
+     */
+    public static void setFilteredTrackList(Model model, Track... toDisplay) {
+        setFilteredTrackList(model, Arrays.asList(toDisplay));
+    }
 
     /**
      * Updates {@code model}'s filtered list to display only {@code toDisplay}.
@@ -33,9 +53,17 @@ public class ModelHelper {
     }
 
     /**
-     * Returns a predicate that evaluates to true if this {@code Person} equals to {@code other}.
+     * Returns a predicate that evaluates to true if this {@code Playlist} equals to {@code other}.
      */
     private static Predicate<Playlist> getPredicateMatching(Playlist other) {
         return playlist -> playlist.equals(other);
     }
+
+    /**
+     * Returns a predicate that evaluates to true if this {@code Track} equals to {@code other}.
+     */
+    private static Predicate<Track> getPredicateMatching(Track other) {
+        return track -> track.equals(other);
+    }
 }
+


### PR DESCRIPTION
Resolves #23, #71 
# Changelog (command):
- trackAddCommand now supports multiple track arguments (i.e. t/track_one t/track_two t/track_three)
- trackAddCommandTest, comprehensive tests written
- trackDeleteCommandTest, comprehensive tests written

# Changelog (testapp):
- CommandParserUtil has new addTracks, addTrack and removeTrack methods
- TestApp now has a filteredTrackList

### Todo:
- [x] Write Tests
- [x] Implementation
- [ ] Edit developer documentation
- [ ] Improve validation for trackAdd & trackDelete